### PR TITLE
Docker build がエラーになる問題を修正する #93

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM node:lts-alpine
-
+FROM node:10.18.1 AS build
+ARG MODE=production
 WORKDIR /app
 
-RUN npm install -g http-server
-
-COPY package*.json ./
-
-RUN npm install
+COPY package*.json .
+RUN npm ci
 
 COPY . .
 
-RUN npm run build
+RUN npx vue-cli-service build --mode $MODE
 
-EXPOSE 8080
-CMD [ "http-server", "dist" ]
+FROM nginx:stable-alpine as runtime
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "npm run test:unit"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
ビルド

```
$ DOCKER_BUILDKIT=1 docker build . -t bms
```

実行

```
$ docker run --rm -p 8080:80 bms
```

↑の場合 `localhost:8080` でアクセスできる（はず）。