### PR TITLE
refs #105 Replaced by createMapper

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -86,19 +86,19 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { SignInModule } from "@/modules/SignInModule";
-import { BooksModule } from "@/modules/BooksModule";
+import { SignInMapper } from "@/modules/SignInModule";
+import { BooksMapper } from "@/modules/BooksModule";
 
 const Super = Vue.extend({
   methods: {
-    ...BooksModule.mapActions(["setFilter"]),
-    ...SignInModule.mapActions(["signOut"])
+    ...BooksMapper.mapActions(["setFilter"]),
+    ...SignInMapper.mapActions(["signOut"])
   },
-  computed: BooksModule.mapGetters(["getFilter"])
+  computed: BooksMapper.mapGetters(["getFilter"])
 });
 
 @Component({
-  computed: SignInModule.mapGetters(["getUser", "isSignIn"])
+  computed: SignInMapper.mapGetters(["getUser", "isSignIn"])
 })
 export default class App extends Super {
   isSignOut: boolean = false;

--- a/src/components/BookDetail.vue
+++ b/src/components/BookDetail.vue
@@ -127,10 +127,10 @@ import { IUser } from "@common/IUser";
 import { getUser } from "@/model/Users";
 import IBook from "@common/IBook";
 import { saveBook, rentBook, returnBook } from "@/model/Book";
-import { BooksModule } from "@/modules/BooksModule";
+import { BooksMapper } from "@/modules/BooksModule";
 
 const Super = Vue.extend({
-  methods: BooksModule.mapActions(["updateBook"])
+  methods: BooksMapper.mapActions(["updateBook"])
 });
 
 @Component({

--- a/src/modules/AuditModule.ts
+++ b/src/modules/AuditModule.ts
@@ -1,4 +1,10 @@
-import { Getters, Mutations, Actions, Module } from 'vuex-smart-module';
+import {
+  Getters,
+  Mutations,
+  Actions,
+  Module,
+  createMapper
+} from 'vuex-smart-module';
 import * as booksManagementEvent from '@common/booksManagementEvent';
 import Audit from '@/model/Audit';
 
@@ -37,3 +43,5 @@ export const AuditModule = new Module({
   mutations: AuditMutations,
   actions: AuditActions
 });
+
+export const AuditMapper = createMapper(AuditModule);

--- a/src/modules/BooksModule.ts
+++ b/src/modules/BooksModule.ts
@@ -1,4 +1,10 @@
-import { Getters, Mutations, Actions, Module } from 'vuex-smart-module';
+import {
+  Getters,
+  Mutations,
+  Actions,
+  Module,
+  createMapper
+} from 'vuex-smart-module';
 import IBook from '@common/IBook';
 import Books from '@/model/Books';
 
@@ -74,3 +80,5 @@ export const BooksModule = new Module({
   mutations: BooksMutations,
   actions: BooksActions
 });
+
+export const BooksMapper = createMapper(BooksModule);

--- a/src/modules/SignInModule.ts
+++ b/src/modules/SignInModule.ts
@@ -1,4 +1,10 @@
-import { Getters, Mutations, Actions, Module } from 'vuex-smart-module';
+import {
+  Getters,
+  Mutations,
+  Actions,
+  Module,
+  createMapper
+} from 'vuex-smart-module';
 import firebase from '@/firebase/firestore';
 import { Auth0Client, auth0Client } from '@/auth0/client';
 
@@ -97,3 +103,5 @@ export const SignInModule = new Module({
   mutations: SignInMutations,
   actions: SignInActions
 });
+
+export const SignInMapper = createMapper(SignInModule);

--- a/src/modules/UserModule.ts
+++ b/src/modules/UserModule.ts
@@ -1,4 +1,10 @@
-import { Getters, Mutations, Actions, Module } from 'vuex-smart-module';
+import {
+  Getters,
+  Mutations,
+  Actions,
+  Module,
+  createMapper
+} from 'vuex-smart-module';
 import { Users } from '@/model/Users';
 
 class UserState {}
@@ -24,3 +30,5 @@ export const UserModule = new Module({
   mutations: UserMutations,
   actions: UserActions
 });
+
+export const UserMapper = createMapper(UserModule);

--- a/src/views/BookEventList.vue
+++ b/src/views/BookEventList.vue
@@ -58,9 +58,9 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { AuditModule } from "@/modules/AuditModule";
-import { BooksModule } from "@/modules/BooksModule";
-import { SignInModule } from "@/modules/SignInModule";
+import { AuditMapper } from "@/modules/AuditModule";
+import { BooksMapper } from "@/modules/BooksModule";
+import { SignInMapper } from "@/modules/SignInModule";
 import { Users, getUser } from "@/model/Users";
 import * as booksManagementEvent from "@common/booksManagementEvent";
 import IBook from "@common/IBook";
@@ -68,13 +68,13 @@ import BookDetail from "@/components/BookDetail.vue";
 
 const Super = Vue.extend({
   methods: {
-    ...BooksModule.mapActions(["updateList", "setCurrentBook"]),
-    ...AuditModule.mapActions(["updateBookEventList"])
+    ...BooksMapper.mapActions(["updateList", "setCurrentBook"]),
+    ...AuditMapper.mapActions(["updateBookEventList"])
   },
   computed: {
-    ...BooksModule.mapGetters(["getFilterdBooks", "getCurrentBook"]),
-    ...AuditModule.mapGetters(["getBookEventList"]),
-    ...SignInModule.mapGetters(["getUser"])
+    ...BooksMapper.mapGetters(["getFilterdBooks", "getCurrentBook"]),
+    ...AuditMapper.mapGetters(["getBookEventList"]),
+    ...SignInMapper.mapGetters(["getUser"])
   }
 });
 

--- a/src/views/BooksList.vue
+++ b/src/views/BooksList.vue
@@ -52,16 +52,16 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
-import { BooksModule } from "@/modules/BooksModule";
-import { SignInModule } from "@/modules/SignInModule";
+import { BooksMapper } from "@/modules/BooksModule";
+import { SignInMapper } from "@/modules/SignInModule";
 import IBook from "@common/IBook";
 import BookDetail from "@/components/BookDetail.vue";
 
 const Super = Vue.extend({
-  methods: BooksModule.mapActions(["updateList", "setCurrentBook"]),
+  methods: BooksMapper.mapActions(["updateList", "setCurrentBook"]),
   computed: {
-    ...BooksModule.mapGetters(["getFilterdBooks", "getCurrentBook"]),
-    ...SignInModule.mapGetters(["getUser"])
+    ...BooksMapper.mapGetters(["getFilterdBooks", "getCurrentBook"]),
+    ...SignInMapper.mapGetters(["getUser"])
   }
 });
 

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -124,12 +124,12 @@ import { getBook, saveBook } from "@/model/Book";
 import IBook from "@common/IBook";
 import Snack from "@/model/Snack.ts";
 import { getUser } from "@/model/Users";
-import { BooksModule } from "@/modules/BooksModule";
-import { SignInModule } from "@/modules/SignInModule";
+import { BooksMapper } from "@/modules/BooksModule";
+import { SignInMapper } from "@/modules/SignInModule";
 
 const Super = Vue.extend({
-  methods: BooksModule.mapActions(["updateList"]),
-  computed: SignInModule.mapGetters(["getUser"])
+  methods: BooksMapper.mapActions(["updateList"]),
+  computed: SignInMapper.mapGetters(["getUser"])
 });
 
 @Component


### PR DESCRIPTION
The following errors are handled by other issues ( #107 )
```
[vuex-smart-module] You are accessing SignInMutations#setFirebaseCustomToken from SignInMutations#updateCurrentUser but accessing another mutation is prohibitted. Use an action to consolidate the mutation chain.
```


-----

closes #105